### PR TITLE
Improve hardware detection defaults

### DIFF
--- a/model_server/config.py
+++ b/model_server/config.py
@@ -36,7 +36,7 @@ def recommend_thread_count(cpu_count: int) -> int:
 def _detect_gpu_with_torch() -> Tuple[int, str]:
     try:  # Optional dependency; avoid hard import failures.
         import torch  # type: ignore
-    except Exception:
+    except (ImportError, ModuleNotFoundError):
         return 0, "unavailable"
 
     try:

--- a/model_server/config.py
+++ b/model_server/config.py
@@ -44,7 +44,7 @@ def _detect_gpu_with_torch() -> Tuple[int, str]:
             count = torch.cuda.device_count() or 0
             if count:
                 return count, "torch.cuda"
-    except Exception:  # pragma: no cover - torch backend errors
+    except RuntimeError:  # pragma: no cover - torch backend errors
         return 0, "torch-error"
     return 0, "torch"
 

--- a/model_server/tests/test_error_paths.py
+++ b/model_server/tests/test_error_paths.py
@@ -1,3 +1,4 @@
+import pytest
 from fastapi.testclient import TestClient
 
 from model_server import server
@@ -19,4 +20,27 @@ def test_chat_returns_500_when_model_unavailable(monkeypatch):
     resp = client.post("/v1/chat/completions", json=payload)
     assert resp.status_code == 500
     assert "no llama" in resp.text
+
+
+def test_get_llama_errors_when_gpu_layers_requested_without_gpu(monkeypatch):
+    class DummyLlama:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("should not construct when GPU unavailable")
+
+    monkeypatch.setattr(server, "_llama_instance", None)
+    monkeypatch.setattr(server, "Llama", DummyLlama)
+    monkeypatch.setattr(server, "_import_err", None)
+    monkeypatch.setattr(server.config, "N_GPU_LAYERS", 2)
+    monkeypatch.setattr(server.config, "GPU_AVAILABLE", False)
+    monkeypatch.setitem(server.config.HARDWARE, "gpu_detection_source", "test")
+    monkeypatch.setitem(server.config.HARDWARE, "configured_gpu_layers", 2)
+    monkeypatch.setitem(server.config.HARDWARE, "gpu_available", False)
+
+    with TestClient(server.app):
+        pass  # ensure FastAPI app doesn't hold onto previous state
+
+    with pytest.raises(RuntimeError) as excinfo:
+        server.get_llama()
+
+    assert "no GPU was detected" in str(excinfo.value)
 

--- a/model_server/tests/test_hardware_detection.py
+++ b/model_server/tests/test_hardware_detection.py
@@ -1,0 +1,65 @@
+import importlib
+import sys
+from types import SimpleNamespace
+
+
+def _reload_config(monkeypatch):
+    """Reload config after clearing common environment overrides."""
+
+    for key in ("CONFIG_PATH", "N_THREADS", "N_GPU_LAYERS", "CUDA_VISIBLE_DEVICES"):
+        monkeypatch.delenv(key, raising=False)
+    import model_server.config as cfg
+
+    return importlib.reload(cfg)
+
+
+def test_cpu_detection_and_recommendation(monkeypatch):
+    cfg = _reload_config(monkeypatch)
+
+    # When cpu_count() is unavailable we fall back to 1.
+    monkeypatch.setattr(cfg.os, "cpu_count", lambda: None)
+    assert cfg.detect_cpu_count() == 1
+
+    # Small machines use all available threads, larger ones leave headroom.
+    assert cfg.recommend_thread_count(1) == 1
+    assert cfg.recommend_thread_count(4) == 4
+
+    monkeypatch.setattr(cfg.os, "cpu_count", lambda: 8)
+    assert cfg.recommend_thread_count(cfg.detect_cpu_count()) == 7
+
+
+def test_gpu_detection_via_environment(monkeypatch):
+    cfg = _reload_config(monkeypatch)
+
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1")
+    cfg = importlib.reload(cfg)
+
+    assert cfg.HARDWARE["gpu_available"] is True
+    assert cfg.HARDWARE["gpu_count"] == 2
+    assert cfg.DEFAULT_GPU_LAYERS == 64
+
+    # Reset to defaults for later tests.
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    importlib.reload(cfg)
+
+
+def test_gpu_detection_via_fake_torch(monkeypatch):
+    cfg = _reload_config(monkeypatch)
+
+    fake_torch = SimpleNamespace(
+        cuda=SimpleNamespace(
+            is_available=lambda: True,
+            device_count=lambda: 3,
+        )
+    )
+
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    cfg = importlib.reload(cfg)
+
+    assert cfg.HARDWARE["gpu_detection_source"] == "torch.cuda"
+    assert cfg.HARDWARE["gpu_count"] == 3
+    assert cfg.DEFAULT_GPU_LAYERS == 80  # capped at safety limit
+
+    # Clean up for other tests: remove fake torch and reload defaults.
+    monkeypatch.delitem(sys.modules, "torch", raising=False)
+    importlib.reload(cfg)

--- a/model_server/tests/test_hardware_detection.py
+++ b/model_server/tests/test_hardware_detection.py
@@ -4,8 +4,15 @@ from types import SimpleNamespace
 
 
 def _reload_config(monkeypatch):
-    """Reload config after clearing common environment overrides."""
+    """
+    Reloads the model_server.config module after clearing common environment overrides.
 
+    This is necessary for test isolation: environment variables can affect config loading,
+    so we clear them and reload the module to ensure each test gets a fresh, consistent config.
+
+    Returns:
+        The reloaded model_server.config module.
+    """
     for key in ("CONFIG_PATH", "N_THREADS", "N_GPU_LAYERS", "CUDA_VISIBLE_DEVICES"):
         monkeypatch.delenv(key, raising=False)
     import model_server.config as cfg

--- a/model_server/tests/test_healthz.py
+++ b/model_server/tests/test_healthz.py
@@ -10,4 +10,8 @@ def test_healthz_ok():
     body = resp.json()
     assert body.get("ok") is True
     assert "model_path" in body
+    assert "hardware" in body
+    hardware = body["hardware"]
+    assert "cpu_count" in hardware
+    assert "gpu_available" in hardware
 


### PR DESCRIPTION
## Summary
- add helpers in the config module to detect CPU/GPU availability and surface smarter defaults
- validate GPU layer requests when no GPU is detected and log the detected hardware at startup
- expose hardware metadata on the health endpoint and extend tests to cover the new behaviors

## Testing
- PYTHONPATH=. pytest model_server -q

------
https://chatgpt.com/codex/tasks/task_e_68e4fc451d4c8328b91f400b8cd33462