### PR TITLE
Handle environments without CUDA for 4-bit LoRA training

### DIFF
--- a/configs/train_lora.example.yaml
+++ b/configs/train_lora.example.yaml
@@ -9,5 +9,5 @@ max_length: 512
 lora_r: 8
 lora_alpha: 16
 lora_dropout: 0.05
-use_4bit: true
+use_4bit: true  # automatically disabled when no CUDA GPU is detected
 # gradient_accumulation_steps: 4  # optional override

--- a/training/README.md
+++ b/training/README.md
@@ -4,7 +4,9 @@ This directory provides a minimal, practical entry to fine-tune a causal LM
 with PEFT/LoRA using Hugging Face Transformers on an instruction-style JSONL.
 
 Why this approach?
-- You can train on full-precision or 4-bit (QLoRA) depending on GPU.
+- You can train on full-precision or 4-bit (QLoRA) depending on GPU. The
+  script automatically disables 4-bit when no CUDA device is available to
+  avoid confusing runtime failures.
 - It’s easy to export a merged adapter back to a HF model and then convert to
   GGUF for llama.cpp inference.
 

--- a/training/train_lora.py
+++ b/training/train_lora.py
@@ -1,9 +1,11 @@
 import argparse
 import json
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
+import torch
 import yaml
 from datasets import load_dataset
 from transformers import (
@@ -66,6 +68,13 @@ def main() -> None:
     args = ap.parse_args()
 
     cfg = load_config(args.config)
+
+    if cfg.use_4bit and not torch.cuda.is_available():
+        warnings.warn(
+            "Requested 4-bit training but no CUDA GPU was detected; disabling 4-bit mode.",
+            RuntimeWarning,
+        )
+        cfg.use_4bit = False
     out_dir = Path(cfg.output_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
## Summary
- guard the 4-bit training path so it is only enabled when CUDA is available
- emit a warning and fall back to full precision if 4-bit is requested without GPU support
- document the automatic fallback in the training README and example config

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4fc4426d4832886f117a6a98fef19